### PR TITLE
Return an unsubscribe method

### DIFF
--- a/test.js
+++ b/test.js
@@ -222,3 +222,18 @@ test(`${prefix}: listeners are cleaned up on completion, and no further listener
 			return observable.forEach(() => {});
 		});
 });
+
+test(`${prefix}: unsubscribing reduces the listener count`, async t => {
+	const ee = new EventEmitter();
+	t.is(listenerCount(ee, 'data'), 0);
+
+	const observable = m(ee);
+
+	const subscription = observable.subscribe({});
+
+	t.is(listenerCount(ee, 'data'), 1);
+
+	subscription.unsubscribe();
+
+	t.is(listenerCount(ee, 'data'), 0);
+});


### PR DESCRIPTION
Fixes #3

This allows observers to unsubscribe from the Observable, consequently removing the event listener from the stream.
