### PR TITLE
Upgrade any-observable@0.3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: node_js
 node_js:
+  - '10'
+  - '8'
   - '6'
-  - '5'
-  - '4'
-  - '0.12'
 
 after_script:
   - 'cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js'

--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 'use strict';
-var Observable = require('any-observable');
+const Observable = require('any-observable');
 
 function or(option, alternate, required) {
-	var result = option === false ? false : option || alternate;
+	const result = option === false ? false : option || alternate;
 
 	if ((required && !result) || (result && typeof result !== 'string')) {
 		throw new TypeError(alternate + 'Event must be a string.');
@@ -11,25 +11,25 @@ function or(option, alternate, required) {
 	return result;
 }
 
-module.exports = function (stream, opts) {
+module.exports = (stream, opts) => {
 	opts = opts || {};
 
-	var complete = false;
-	var dataListeners = [];
-	var awaited = opts.await;
-	var dataEvent = or(opts.dataEvent, 'data', true);
-	var errorEvent = or(opts.errorEvent, 'error');
-	var endEvent = or(opts.endEvent, 'end');
+	let complete = false;
+	let dataListeners = [];
+	const awaited = opts.await;
+	const dataEvent = or(opts.dataEvent, 'data', true);
+	const errorEvent = or(opts.errorEvent, 'error');
+	const endEvent = or(opts.endEvent, 'end');
 
 	function cleanup() {
 		complete = true;
-		dataListeners.forEach(function (listener) {
+		dataListeners.forEach(listener => {
 			stream.removeListener(dataEvent, listener);
 		});
 		dataListeners = null;
 	}
 
-	var completion = new Promise(function (resolve, reject) {
+	const completion = new Promise((resolve, reject) => {
 		function onEnd(result) {
 			if (awaited) {
 				awaited.then(resolve);
@@ -51,15 +51,15 @@ module.exports = function (stream, opts) {
 		if (awaited) {
 			awaited.catch(reject);
 		}
-	}).catch(function (err) {
+	}).catch(err => {
 		cleanup();
 		throw err;
-	}).then(function (result) {
+	}).then(result => {
 		cleanup();
 		return result;
 	});
 
-	return new Observable(function (observer) {
+	return new Observable(observer => {
 		completion
 			.then(observer.complete.bind(observer))
 			.catch(observer.error.bind(observer));
@@ -68,21 +68,21 @@ module.exports = function (stream, opts) {
 			return null;
 		}
 
-		var onData = function onData(data) {
+		const onData = data => {
 			observer.next(data);
 		};
 
 		stream.on(dataEvent, onData);
 		dataListeners.push(onData);
 
-		return function () {
+		return () => {
 			stream.removeListener(dataEvent, onData);
 
 			if (complete) {
 				return;
 			}
 
-			var idx = dataListeners.indexOf(onData);
+			const idx = dataListeners.indexOf(onData);
 
 			if (idx !== -1) {
 				dataListeners.splice(idx, 1);

--- a/license
+++ b/license
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) James Talmage <james@talmage.io> (github.com/jamestalmage)
+Copyright (c) James Talmage <james@talmage.io> (github.com/jamestalmage), Sam Verschueren <sam.verschueren@gmail.com> (github.com/SamVerschueren)
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/package.json
+++ b/package.json
@@ -1,14 +1,16 @@
 {
-  "name": "stream-to-observable",
+  "name": "@samverschueren/stream-to-observable",
   "version": "0.2.0",
   "description": "Convert Node Streams into ECMAScript-Observables",
   "license": "MIT",
-  "repository": "jamestalmage/stream-to-observable",
-  "author": {
-    "name": "James Talmage",
-    "email": "james@talmage.io",
-    "url": "github.com/jamestalmage"
-  },
+  "repository": "SamVerschueren/stream-to-observable",
+  "maintainers": [
+    {
+      "name": "Sam Verschueren",
+      "email": "sam.verschueren@gmail.com",
+      "url": "github.com/SamVerschueren"
+    }
+  ],
   "engines": {
     "node": ">=6"
   },

--- a/package.json
+++ b/package.json
@@ -10,17 +10,14 @@
     "url": "github.com/jamestalmage"
   },
   "engines": {
-    "node": ">=0.12.0"
+    "node": ">=6"
   },
   "scripts": {
     "test": "xo && nyc --reporter=lcov --reporter=text npm run test_both",
     "test_both": "ava --require=any-observable/register/rxjs && ava --require=any-observable/register/zen"
   },
   "files": [
-    "index.js",
-    "zen.js",
-    "rxjs.js",
-    "rxjs-all.js"
+    "index.js"
   ],
   "keywords": [
     "stream",
@@ -32,22 +29,12 @@
   },
   "devDependencies": {
     "array-to-events": "^1.0.0",
-    "ava": "^0.15.2",
-    "coveralls": "^2.11.9",
-    "delay": "^1.3.1",
-    "nyc": "^6.4.0",
-    "rxjs": "^5.0.0-beta.6",
-    "xo": "^0.16.0",
-    "zen-observable": "^0.3.0"
-  },
-  "xo": {
-    "overrides": [
-      {
-        "files": [
-          "test.js"
-        ],
-        "esnext": true
-      }
-    ]
+    "ava": "^0.25.0",
+    "coveralls": "^3.0.0",
+    "delay": "^2.0.0",
+    "nyc": "^11.7.1",
+    "rxjs": "^5.5.10",
+    "xo": "^0.20.3",
+    "zen-observable": "^0.8.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "convert"
   ],
   "dependencies": {
-    "any-observable": "^0.2.0"
+    "any-observable": "^0.3.0"
   },
   "devDependencies": {
     "array-to-events": "^1.0.0",

--- a/readme.md
+++ b/readme.md
@@ -1,4 +1,4 @@
-# stream-to-observable [![Build Status](https://travis-ci.org/jamestalmage/stream-to-observable.svg?branch=master)](https://travis-ci.org/jamestalmage/stream-to-observable) [![Coverage Status](https://coveralls.io/repos/github/jamestalmage/stream-to-observable/badge.svg?branch=master)](https://coveralls.io/github/jamestalmage/stream-to-observable?branch=master)
+# stream-to-observable [![Build Status](https://travis-ci.org/SamVerschueren/stream-to-observable.svg?branch=master)](https://travis-ci.org/SamVerschueren/stream-to-observable) [![Coverage Status](https://coveralls.io/repos/github/SamVerschueren/stream-to-observable/badge.svg?branch=master)](https://coveralls.io/github/SamVerschueren/stream-to-observable?branch=master)
 
 > Convert Node Streams into ECMAScript-Observables
 
@@ -6,11 +6,12 @@
 
 [Learn more about Observables](#learn-about-observables)
 
+**Note:** This module was forked from [`stream-to-observable`](https://github.com/jamestalmage/stream-to-observable) and released under a different name due to inactivity.
+
 ## Install
 
 ```
-$ npm install --save stream-to-observable
-
+$ npm install --save @samverschueren/stream-to-observable
 ```
 
 `stream-to-observable` relies on [`any-observable`](https://github.com/sindresorhus/any-observable), which will search for an available Observable implementation. You need to install one yourself:
@@ -33,7 +34,7 @@ If your code relies on a specific Observable implementation, you should likely s
 const fs = require('fs');
 const split = require('split');
 
-const streamToObservable = require('stream-to-observable');
+const streamToObservable = require('@samverschueren/stream-to-observable');
 
 const readStream = fs
   .createReadStream('./hello-world.txt', {encoding: 'utf8'})
@@ -113,4 +114,4 @@ It's important to note that using this module disables back-pressure controls on
 
 ## License
 
-MIT © [James Talmage](https://github.com/jamestalmage)
+MIT


### PR DESCRIPTION
This is necessary in order to be able to use RxJS@6 with `stream-to-observable`. One downside is that `any-observable@0.3.0` required Node.js 6. So probably the tests will start failing. I can ES2016ify the codebase in a separate PR if you want.

// @sindresorhus 