### PR TITLE
Drop support for Node.js 0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,6 @@ node_js:
   - '6'
   - '5'
   - '4'
-  - '0.12'
 
 after_script:
   - 'cat ./coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js'

--- a/index.js
+++ b/index.js
@@ -1,8 +1,8 @@
 'use strict';
-var Observable = require('any-observable');
+const Observable = require('any-observable');
 
 function or(option, alternate, required) {
-	var result = option === false ? false : option || alternate;
+	const result = option === false ? false : option || alternate;
 
 	if ((required && !result) || (result && typeof result !== 'string')) {
 		throw new TypeError(alternate + 'Event must be a string.');
@@ -11,25 +11,25 @@ function or(option, alternate, required) {
 	return result;
 }
 
-module.exports = function (stream, opts) {
+module.exports = (stream, opts) => {
 	opts = opts || {};
 
-	var complete = false;
-	var dataListeners = [];
-	var awaited = opts.await;
-	var dataEvent = or(opts.dataEvent, 'data', true);
-	var errorEvent = or(opts.errorEvent, 'error');
-	var endEvent = or(opts.endEvent, 'end');
+	let complete = false;
+	let dataListeners = [];
+	const awaited = opts.await;
+	const dataEvent = or(opts.dataEvent, 'data', true);
+	const errorEvent = or(opts.errorEvent, 'error');
+	const endEvent = or(opts.endEvent, 'end');
 
 	function cleanup() {
 		complete = true;
-		dataListeners.forEach(function (listener) {
+		dataListeners.forEach(listener => {
 			stream.removeListener(dataEvent, listener);
 		});
 		dataListeners = null;
 	}
 
-	var completion = new Promise(function (resolve, reject) {
+	const completion = new Promise((resolve, reject) => {
 		function onEnd(result) {
 			if (awaited) {
 				awaited.then(resolve);
@@ -51,15 +51,15 @@ module.exports = function (stream, opts) {
 		if (awaited) {
 			awaited.catch(reject);
 		}
-	}).catch(function (err) {
+	}).catch(err => {
 		cleanup();
 		throw err;
-	}).then(function (result) {
+	}).then(result => {
 		cleanup();
 		return result;
 	});
 
-	return new Observable(function (observer) {
+	return new Observable(observer => {
 		completion
 			.then(observer.complete.bind(observer))
 			.catch(observer.error.bind(observer));
@@ -68,21 +68,21 @@ module.exports = function (stream, opts) {
 			return null;
 		}
 
-		var onData = function onData(data) {
+		const onData = data => {
 			observer.next(data);
 		};
 
 		stream.on(dataEvent, onData);
 		dataListeners.push(onData);
 
-		return function () {
+		return () => {
 			stream.removeListener(dataEvent, onData);
 
 			if (complete) {
 				return;
 			}
 
-			var idx = dataListeners.indexOf(onData);
+			const idx = dataListeners.indexOf(onData);
 
 			if (idx !== -1) {
 				dataListeners.splice(idx, 1);

--- a/package.json
+++ b/package.json
@@ -10,17 +10,14 @@
     "url": "github.com/jamestalmage"
   },
   "engines": {
-    "node": ">=0.12.0"
+    "node": ">=4"
   },
   "scripts": {
     "test": "xo && nyc --reporter=lcov --reporter=text npm run test_both",
     "test_both": "ava --require=any-observable/register/rxjs && ava --require=any-observable/register/zen"
   },
   "files": [
-    "index.js",
-    "zen.js",
-    "rxjs.js",
-    "rxjs-all.js"
+    "index.js"
   ],
   "keywords": [
     "stream",
@@ -32,22 +29,12 @@
   },
   "devDependencies": {
     "array-to-events": "^1.0.0",
-    "ava": "^0.15.2",
-    "coveralls": "^2.11.9",
-    "delay": "^1.3.1",
-    "nyc": "^6.4.0",
-    "rxjs": "^5.0.0-beta.6",
-    "xo": "^0.16.0",
-    "zen-observable": "^0.3.0"
-  },
-  "xo": {
-    "overrides": [
-      {
-        "files": [
-          "test.js"
-        ],
-        "esnext": true
-      }
-    ]
+    "ava": "^0.25.0",
+    "coveralls": "^3.0.0",
+    "delay": "^2.0.0",
+    "nyc": "^11.7.1",
+    "rxjs": "^5.5.10",
+    "xo": "^0.20.3",
+    "zen-observable": "^0.8.8"
   }
 }


### PR DESCRIPTION
As discussed in #10, I ES2016ified the codebase and dropped support for Node.js 0.12. I also upgraded the dependencies. There where 2 tests where Zen and RxJS didn't give the same result back, this seems to be fixed in Zen so all tests are now the same for both implementations.

Wasn't sure about the commit message, feel free to change it while merging or suggest an alternative.